### PR TITLE
Add the optional `purchase-premium-dns` field when renewing a domain

### DIFF
--- a/src/APIs/Domains.php
+++ b/src/APIs/Domains.php
@@ -318,30 +318,35 @@ class Domains
     }
 
     /**
-     * @param int     $orderId
-     * @param int     $years
-     * @param int     $exp
-     * @param boolean $purchasePrivacy
-     * @param string  $invoice Available options [NoInvoice, PayInvoice, KeepInvoice, OnlyAdd]
+     * @param int          $orderId
+     * @param int          $years
+     * @param int          $exp
+     * @param boolean      $purchasePrivacy
+     * @param string       $invoice Available options [NoInvoice, PayInvoice, KeepInvoice, OnlyAdd]
+     * @param boolean|null $purchasePremiumDns
      *
      * @return array|Exception
      * @throws Exception
      * @link https://manage.logicboxes.com/kb/node/746
      */
-    public function renew($orderId, $years, $exp, $purchasePrivacy, $invoice)
+    public function renew($orderId, $years, $exp, $purchasePrivacy, $invoice, $purchasePremiumDns = null)
     {
-        return $this->postArgString(
-            'renew',
-            http_build_query(
-                [
-                    'order-id'         => $orderId,
-                    'years'            => $years,
-                    'exp-date'         => strtotime($exp),
-                    'purchase-privacy' => $purchasePrivacy,
-                    'invoice-option'   => $invoice,
-                ]
-            )
-        );
+        $params = [
+            'order-id'         => $orderId,
+            'years'            => $years,
+            'exp-date'         => strtotime($exp),
+            'purchase-privacy' => $purchasePrivacy,
+            'invoice-option'   => $invoice,
+        ];
+
+        if (is_bool($purchasePremiumDns)) {
+            $params = array_merge(
+                ['purchase-premium-dns' => $purchasePremiumDns ? 'true' : 'false'],
+                $params
+            );
+        }
+
+        return $this->post('renew', $params);
     }
 
     /**

--- a/src/APIs/Domains.php
+++ b/src/APIs/Domains.php
@@ -341,8 +341,8 @@ class Domains
 
         if (is_bool($purchasePremiumDns)) {
             $params = array_merge(
-                ['purchase-premium-dns' => $purchasePremiumDns ? 'true' : 'false'],
-                $params
+                $params,
+                ['purchase-premium-dns' => $purchasePremiumDns ? 'true' : 'false']
             );
         }
 


### PR DESCRIPTION
### What does it do?
Make it possible to use the optional `purchase-premium-dns` field when renewing a domain. Since it's an optional field with no default value we only add it when a boolean value is given.